### PR TITLE
Fix ACCOUNT_CONFIRM_EMAIL_ON_GET for django-allauth

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -260,7 +260,7 @@ ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS = False  # otherwise admins can't access the login view
 LOGIN_REDIRECT_URL = '/'
-CONFIRM_EMAIL_ON_GET = True
+ACCOUNT_CONFIRM_EMAIL_ON_GET = True
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator'},  # removes frustrating validations, eg `too similar to your email`
 ]


### PR DESCRIPTION
According to django-allauth documentation(https://django-allauth.readthedocs.io/en/latest/configuration.html) it should be named like `ACCOUNT_CONFIRM_EMAIL_ON_GET`