### PR TITLE
adds parler to INSTALLED_APPS for availability on the blog module

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -164,6 +164,7 @@ INSTALLED_APPS.extend([
     'djangocms_redirect',
     'light_gallery',
     'link_all',
+    'parler',
 
     # django-filer
     'easy_thumbnails',


### PR DESCRIPTION
Adding new blog posts is not posible without the parler module loaded.

Fresh install: http://localhost:8000/en/blog/?edit&language=en

![2022-07-21-123133_731x388_scrot](https://user-images.githubusercontent.com/211201/180276791-d4fadeca-dfa4-4277-82df-8ec118b250f6.png)
